### PR TITLE
Use r-forge git mirror

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5,7 +5,7 @@
     },
     {
         "package": "glmertree",
-        "url": "https://r-forge.r-project.org/projects/partykit",
+        "url": "https://github.com/r-forge/partykit",
         "subdir": "pkg/glmertree"
     },
     {


### PR DESCRIPTION
R-universe can only clone from git urls, not svn. So we use the github mirror source.

Fixes https://github.com/r-universe/marjoleinf/actions/runs/14475411526